### PR TITLE
add travis job to build and push docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+
+language: generic
+
+services:
+  - docker
+
+before_install:
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+jobs:
+  include:
+    - stage: push-dpdk-image
+      script: make -f docker.mk -e CONTAINER=dpdk image-fresh
+      if: branch = master
+    - stage: build-dpdk-image
+      script: make -f docker.mk -e CONTAINER=dpdk build-fresh
+      if: branch != master
+    - stage: push-sandbox-image
+      script: make -f docker.mk -e CONTAINER=sandbox image-fresh
+      if: branch = master
+    - stage: build-sandbox-image
+      script: make -f docker.mk -e CONTAINER=sandbox build-fresh
+      if: branch != master


### PR DESCRIPTION
Right now all it does is build, tag and push the images to docker hub. Two env variables, `DOCKER_PASSWORD` and `DOCKER_USERNAME` will have to be defined. I used the web portal but they can also be encrypted and embedded in the yaml file as well. Not sure what is preferred.

Also the approach is rather simplistic right now. I don't know if we want to break this apart so we can run some tests/validation before pushing the images up to the hub.