### PR TITLE
make netbricks the default vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,8 @@ $dtag = ENV.fetch("DTAG", "latest")
 $dproject = ENV.fetch("DPROJECT", "williamofockham")
 $nbpath = ENV.fetch("NBPATH", "../NetBricks")
 $mgpath = ENV.fetch("MGPATH", "../MoonGen")
+$dpdk_driver = ENV.fetch("DPDK_DRIVER", "uio_pci_generic")
+$dpdk_devices = ENV.fetch("DPDK_DEVICES", "0000:00:08.0 0000:00:09.0")
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # All Vagrant configuration is done here. The most common configuration
@@ -59,7 +61,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                    -v /var/run:/var/run).join(" "),
           restart: "no",
           daemonize: true,
-          cmd: "/bin/bash -c '/dpdk/usertools/dpdk-devbind.py --force -b uio_pci_generic 0000:00:08.0 0000:00:09.0'"
+          cmd: "/bin/bash -c '/dpdk/usertools/dpdk-devbind.py --force -b #{$dpdk_driver} #{$dpdk_devices}'"
   end
 
   # VirtualBox-specific configuration

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,10 @@
 # Vagrant file API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+def path_exists?(path)
+  File.directory?(path)
+end
+
 $dimage = ENV.fetch("DIMAGE", "netbricks")
 $dtag = ENV.fetch("DTAG", "latest")
 $dproject = ENV.fetch("DPROJECT", "williamofockham")
@@ -16,10 +20,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/xenial64"
   config.disksize.size = "30GB"
   config.vm.synced_folder ".", "/vagrant", disabled: false
-  config.vm.synced_folder $nbpath, "/NetBricks", disabled: false
-  config.vm.synced_folder $mgpath, "/MoonGen", disabled: false
-
-  config.vm.define $dimage
+  if path_exists?($nbpath)
+    config.vm.synced_folder $nbpath, "/NetBricks", disabled: false
+  end
+  if path_exists?($mgpath)
+    config.vm.synced_folder $mgpath, "/MoonGen", disabled: false
+  end
 
   # Create a private network, which allows host-only access to the machine using a
   # specific IP. This option is needed because DPDK takes over the NIC.
@@ -28,7 +34,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Setup the VM for DPDK, including binding the extra interface via the fetched
   # container
-  config.vm.provision "shell", path: "vm-setup.sh", args: $dtag
+  config.vm.provision "shell", path: "vm-setup.sh"
 
   # Pull and run (then remove) our image in order to do the devbind
   config.vm.provision "docker" do |d|
@@ -59,7 +65,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # VirtualBox-specific configuration
   config.vm.provider "virtualbox" do |vb|
     # Set machine name, memory and CPU limits
-    vb.name = "ubuntu-xenial-#{$dimage}"
+    vb.name = "ubuntu-xenial-williamofockham"
     vb.memory = 4096
     vb.cpus = 2
 


### PR DESCRIPTION
It's a little bit awkward to ssh into one that's not netbricks. `DIMAGE=sandbox vagrant ssh`.