### PR TITLE
add tcpreplay, cargo expand for macros, clippy ain't cool no more (til we update rust v)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ corectl/*-version.txt
 .vagrant
 *.log
 MoonGen
+*.pcap

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -3,7 +3,7 @@ FROM williamofockham/moongen AS moongen
 FROM williamofockham/dpdk
 
 ENV NIGHTLY_DATE 2018-04-12
-ENV CLIPPY_VERS 0.0.197
+ENV CLIPPY_VERSION 0.0.197
 ENV RUSTUP_TOOLCHAIN=nightly-$NIGHTLY_DATE \
 PATH=$PATH:/root/.cargo/bin
 
@@ -45,7 +45,9 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUSTUP_TOO
     cargo --version; \
     rustc --version && \
     rustup component add rustfmt-preview rust-src && \
-    cargo install clippy --version $CLIPPY_VERS cargo-watch cargo-expand && \
+    cargo install clippy --version $CLIPPY_VERSION && \
+    cargo install cargo-watch cargo-expand && \
+    rm -rf /usr/local/cargo/registry && \
     pip install Pygments \
     --upgrade pip && \
     apt-get purge --auto-remove -y curl && \

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -45,7 +45,6 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUSTUP_TOO
     cargo --version; \
     rustc --version && \
     rustup component add rustfmt-preview rust-src && \
-    cargo install clippy --version $CLIPPY_VERSION && \
     cargo install cargo-watch cargo-expand && \
     rm -rf /usr/local/cargo/registry && \
     pip install Pygments \

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -3,11 +3,14 @@ FROM williamofockham/moongen AS moongen
 FROM williamofockham/dpdk
 
 ENV NIGHTLY_DATE 2018-04-12
+ENV CLIPPY_VERS 0.0.197
 ENV RUSTUP_TOOLCHAIN=nightly-$NIGHTLY_DATE \
 PATH=$PATH:/root/.cargo/bin
 
 ARG cargo_inc=0
+ARG rust_backtrace=1
 ENV CARGO_INCREMENTAL=$cargo_inc
+ENV RUST_BACKTRACE=$rust_backtrace
 
 COPY --from=moongen /opt/moongen /opt/moongen
 
@@ -33,6 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     musl-tools \
     net-tools \
     tcpdump \
+    tcpreplay \
     valgrind \
     sudo
 
@@ -41,7 +45,9 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUSTUP_TOO
     cargo --version; \
     rustc --version && \
     rustup component add rustfmt-preview rust-src && \
-    cargo install clippy cargo-watch && \
+    cargo install clippy --version $CLIPPY_VERS cargo-watch cargo-expand && \
+    pip install Pygments \
+    --upgrade pip && \
     apt-get purge --auto-remove -y curl && \
     rm -rf /var/lib/apt /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
… and backtrace always.

- We should eventually update Rust to a new version or 1.26 stable, but this is no that pr. We need rust-backtrace per env, and cargo-expand for macro fun.