### PR TITLE
Sandbox setup for bcc

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -13,6 +13,8 @@ ENV RUST_BACKTRACE=$rust_backtrace
 
 COPY --from=moongen /opt/moongen /opt/moongen
 
+RUN echo "deb [trusted=yes] http://repo.iovisor.org/apt/xenial xenial-nightly main" > /etc/apt/sources.list.d/iovisor.list;
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-utils \
     bash \
@@ -37,7 +39,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tcpdump \
     tcpreplay \
     valgrind \
-    sudo
+    sudo \
+    netcat \
+    bcc-tools \
+    python-pyroute2
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUSTUP_TOOLCHAIN && \
     rustup --version; \
@@ -53,5 +58,9 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUSTUP_TOO
 
 RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump
 
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
 WORKDIR /opt/sandbox
-CMD /bin/bash
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,7 +43,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # specific IP. This option is needed because DPDK takes over the NIC.
   config.vm.network "private_network", ip: "10.1.2.2", mac: "BADCAFEBEEF1", nic_type: "virtio"
   config.vm.network "private_network", ip: "10.1.2.3", mac: "BADCAFEBEEF2", nic_type: "virtio"
-
+  config.vm.network "private_network", ip: "fe80::b8dc:afff:feeb:eef3", mac: "BADCAFEBEEF3"
+  config.vm.network "private_network", ip: "fe80::b8dc:afff:feeb:eef4", mac: "BADCAFEBEEF4"
+  
   # Setup the VM for DPDK, including binding the extra interface via the fetched
   # container
   config.vm.provision "shell", path: "vm-kernel-upgrade.sh"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+mount -t debugfs none /sys/kernel/debug/
+exec "$@"


### PR DESCRIPTION
Adds bcc-tools, netcat and pyroute2 to the container and mounts
the debug filesystem for tracing.

The vagrant also has two ipv6 virtual interfaces ready for agent
testing.